### PR TITLE
[#1] Stemming CLI implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,17 @@
 .*
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+vendor/
+
+# Go workspace file
 go.work
-go.sum

--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,3 @@
-# If you prefer the allow list template instead of the deny list, see community template:
-# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
-#
-# Binaries for programs and plugins
-*.exe
-*.exe~
-*.dll
-*.so
-*.dylib
-
-# Test binary, built with `go test -c`
-*.test
-
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
-
-# Dependency directories (remove the comment below to include it)
-# vendor/
-
-# Go workspace file
+.*
 go.work
+go.sum

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/AntonShadrinNN/comix-search
 
 go 1.22.1
 
-require github.com/kljensen/snowball v0.9.0 // indirect
+require github.com/kljensen/snowball v0.9.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/AntonShadrinNN/comix-search
+
+go 1.22.1
+
+require github.com/kljensen/snowball v0.9.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,13 @@ module github.com/AntonShadrinNN/comix-search
 
 go 1.22.1
 
-require github.com/kljensen/snowball v0.9.0
+require (
+	github.com/kljensen/snowball v0.9.0
+	github.com/stretchr/testify v1.9.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/kljensen/snowball v0.9.0 h1:OpXkQBcic6vcPG+dChOGLIA/GNuVg47tbbIJ2s7Keas=
+github.com/kljensen/snowball v0.9.0/go.mod h1:OGo5gFWjaeXqCu4iIrMl5OYip9XUJHGOU5eSkPjVg2A=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/kljensen/snowball v0.9.0 h1:OpXkQBcic6vcPG+dChOGLIA/GNuVg47tbbIJ2s7Keas=
 github.com/kljensen/snowball v0.9.0/go.mod h1:OGo5gFWjaeXqCu4iIrMl5OYip9XUJHGOU5eSkPjVg2A=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/stem/Makefile
+++ b/stem/Makefile
@@ -1,0 +1,19 @@
+# Определение переменных
+GOCMD=go
+GOBUILD=$(GOCMD) build
+BINARY_NAME=stem
+
+build:
+	$(GOCMD) mod tidy
+	$(GOBUILD) -o $(BINARY_NAME) ./...
+
+clean:
+	rm -f $(BINARY_NAME)
+
+install:
+	$(GOBUILD) -o $(GOPATH)/bin/$(BINARY_NAME) -v
+
+uninstall:
+	rm -f $(GOPATH)/bin/$(BINARY_NAME)
+
+default: build

--- a/stem/README.md
+++ b/stem/README.md
@@ -1,0 +1,24 @@
+# Stem
+![Go](https://img.shields.io/badge/go-%2300ADD8.svg?style=for-the-badge&logo=go&logoColor=white)
+![GitHub](https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white)
+
+Stem CLI reduces inflected words to their word stem. Currently [snowball module](https://github.com/kljensen/snowball.git) is used.
+
+## Install
+```sh
+git clone git@github.com:AntonShadrinNN/comix-search.git
+cd stem
+make build && sudo make install
+```
+
+## Uninstall
+```sh
+cd stem
+sudo make uninstall && make clean
+```
+
+## Usage
+After installation you can simply run `stem -s="String to stem"` and see the result.
+
+> [!IMPORTANT]
+> Make sure to provide flag `-s`. It is mandatory

--- a/stem/cli.go
+++ b/stem/cli.go
@@ -1,3 +1,16 @@
+/*
+Stem reduces inflected words to their word stem.
+It uses external stemming module.
+
+Usage:
+
+	stem [flags]
+
+The flags are:
+
+	-s
+	    Sentence to stem.
+*/
 package main
 
 import (
@@ -8,11 +21,13 @@ const (
 	initialStringFlagName = "s"
 )
 
+// A Flags represents data parsed from command line
 type Flags struct {
 	InitialString string
 }
 
-func (f Flags) validateFlags() error {
+// ValidateFlags validates flags provided through command line
+func (f Flags) ValidateFlags() error {
 	if f.InitialString == "" {
 		return errFlagIsMandatory(initialStringFlagName)
 	}
@@ -20,6 +35,7 @@ func (f Flags) validateFlags() error {
 	return nil
 }
 
+// ParseFlags parses flags from command line
 func ParseFlags() Flags {
 	var flags Flags
 

--- a/stem/cli.go
+++ b/stem/cli.go
@@ -20,16 +20,11 @@ func (f Flags) validateFlags() error {
 	return nil
 }
 
-func ParseFlags() (Flags, error) {
+func ParseFlags() Flags {
 	var flags Flags
 
 	flag.StringVar(&flags.InitialString, initialStringFlagName, "", "Mandatory. String to stem")
 	flag.Parse()
 
-	err := flags.validateFlags()
-	if err != nil {
-		return Flags{}, err
-	}
-
-	return flags, nil
+	return flags
 }

--- a/stem/cli.go
+++ b/stem/cli.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"flag"
+)
+
+const (
+	initialStringFlagName = "s"
+)
+
+type Flags struct {
+	InitialString string
+}
+
+func (f Flags) validateFlags() error {
+	if f.InitialString == "" {
+		return errFlagIsMandatory(initialStringFlagName)
+	}
+
+	return nil
+}
+
+func ParseFlags() (Flags, error) {
+	var flags Flags
+
+	flag.StringVar(&flags.InitialString, initialStringFlagName, "", "Mandatory. String to stem")
+	flag.Parse()
+
+	err := flags.validateFlags()
+	if err != nil {
+		return Flags{}, err
+	}
+
+	return flags, nil
+}

--- a/stem/cli_test.go
+++ b/stem/cli_test.go
@@ -32,7 +32,7 @@ func TestFlagsValidation(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		err := testCase.FlagsData.validateFlags()
+		err := testCase.FlagsData.ValidateFlags()
 		assert.Equal(t, testCase.Err, err)
 	}
 }
@@ -53,7 +53,7 @@ func TestGetCommandLineFlags(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		err := testCase.ExpectedFlags.validateFlags()
+		err := testCase.ExpectedFlags.ValidateFlags()
 		assert.Equal(t, testCase.Err, err)
 	}
 }

--- a/stem/cli_test.go
+++ b/stem/cli_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	someStr = "some string"
+)
+
+func TestFlagsValidation(t *testing.T) {
+	testCases := []struct {
+		FlagsData Flags
+		Err       error
+	}{
+		{
+			FlagsData: Flags{
+				InitialString: "",
+			},
+			Err: errFlagIsMandatory(initialStringFlagName),
+		},
+		{
+			FlagsData: Flags{
+				InitialString: "some value",
+			},
+			Err: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		err := testCase.FlagsData.validateFlags()
+		assert.Equal(t, testCase.Err, err)
+	}
+}
+
+func TestGetCommandLineFlags(t *testing.T) {
+	testCases := []struct {
+		Err           error
+		ExpectedFlags Flags
+	}{
+		{
+			Err:           errFlagIsMandatory(initialStringFlagName),
+			ExpectedFlags: Flags{},
+		},
+		{
+			Err:           nil,
+			ExpectedFlags: Flags{InitialString: someStr},
+		},
+	}
+
+	for _, testCase := range testCases {
+		err := testCase.ExpectedFlags.validateFlags()
+		assert.Equal(t, testCase.Err, err)
+	}
+}
+
+func TestParseFlags(t *testing.T) {
+	args := []string{fmt.Sprintf("-s=%s", someStr)}
+
+	// Сохраняем исходные аргументы командной строки
+	originalArgs := os.Args
+
+	// Подменяем аргументы командной строки для теста
+	os.Args = append([]string{originalArgs[0]}, args...)
+
+	flags := ParseFlags()
+
+	assert.Equal(t, someStr, flags.InitialString)
+	os.Args = originalArgs
+}

--- a/stem/errors.go
+++ b/stem/errors.go
@@ -2,4 +2,5 @@ package main
 
 import "fmt"
 
+// errFlagIsMandatory is used to notify user, that flag must be provided
 var errFlagIsMandatory = func(flag string) error { return fmt.Errorf("flag %s is mandatory", flag) }

--- a/stem/errors.go
+++ b/stem/errors.go
@@ -1,0 +1,5 @@
+package main
+
+import "fmt"
+
+var errFlagIsMandatory = func(flag string) error { return fmt.Errorf("flag %s is mandatory", flag) }

--- a/stem/errors_test.go
+++ b/stem/errors_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrFlagIsMandatory(t *testing.T) {
+	flag := "some_flag"
+	expected := fmt.Sprintf("flag %s is mandatory", flag)
+	got := errFlagIsMandatory(flag)
+
+	assert.Equal(t, expected, got.Error(), "Expected another error message")
+}

--- a/stem/languages.go
+++ b/stem/languages.go
@@ -1,5 +1,6 @@
 package main
 
+// A Language represents natural language for stemming libraries
 type Language = string
 
 var (

--- a/stem/languages.go
+++ b/stem/languages.go
@@ -1,0 +1,8 @@
+package main
+
+type Language = string
+
+var (
+	English = Language("english")
+	Russian = Language("Russian")
+)

--- a/stem/languages.go
+++ b/stem/languages.go
@@ -4,5 +4,5 @@ type Language = string
 
 var (
 	English = Language("english")
-	Russian = Language("Russian")
+	Russian = Language("russian")
 )

--- a/stem/main.go
+++ b/stem/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"log"
+	"strings"
+)
+
+func main() {
+	flags, err := ParseFlags()
+	if err != nil {
+		panic(err)
+	}
+
+	stemmed, err := Stem(strings.Split(flags.InitialString, " "), English)
+	if err != nil {
+		panic(err)
+	}
+	log.Printf(stemmed)
+}

--- a/stem/main.go
+++ b/stem/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strings"
 )
 
+// getStopWords returns most frequent english words
+// Currently data is taken from open bases
 func getStopWords() ([]string, error) {
 	resp, err := http.Get("https://gist.githubusercontent.com/rg089/35e00abf8941d72d419224cfd5b5925d/raw/12d899b70156fd0041fa9778d657330b024b959c/stopwords.txt")
 	if err != nil {
@@ -23,9 +25,9 @@ func getStopWords() ([]string, error) {
 func main() {
 	flags := ParseFlags()
 
-	err := flags.validateFlags()
+	err := flags.ValidateFlags()
 	if err != nil {
-		panic(err)
+		fmt.Printf("Failed to parse flags: %+v\n", err)
 	}
 
 	stemmer := SnowballStemmer{
@@ -34,7 +36,8 @@ func main() {
 	}
 	stemmed, err := stemmer.Stem(strings.Split(flags.InitialString, " "))
 	if err != nil {
-		panic(err)
+		fmt.Printf("Failed to stem provided string: %+v\n", err)
 	}
-	log.Printf(stemmed)
+
+	fmt.Println(stemmed)
 }

--- a/stem/main.go
+++ b/stem/main.go
@@ -1,17 +1,38 @@
 package main
 
 import (
+	"io"
 	"log"
+	"net/http"
 	"strings"
 )
 
+func getStopWords() ([]string, error) {
+	resp, err := http.Get("https://gist.githubusercontent.com/rg089/35e00abf8941d72d419224cfd5b5925d/raw/12d899b70156fd0041fa9778d657330b024b959c/stopwords.txt")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(string(data), "\n"), nil
+}
+
 func main() {
-	flags, err := ParseFlags()
+	flags := ParseFlags()
+
+	err := flags.validateFlags()
 	if err != nil {
 		panic(err)
 	}
 
-	stemmed, err := Stem(strings.Split(flags.InitialString, " "), English)
+	stemmer := SnowballStemmer{
+		language:      English,
+		stopWordsFunc: getStopWords,
+	}
+	stemmed, err := stemmer.Stem(strings.Split(flags.InitialString, " "))
 	if err != nil {
 		panic(err)
 	}

--- a/stem/stem.go
+++ b/stem/stem.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/kljensen/snowball"
+)
+
+func Stem(words []string, language Language) (string, error) {
+	stopWords, err := getStopWords()
+	if err != nil {
+		return "", err
+	}
+
+	stemmedSentence := make([]string, 0, len(words))
+	for _, word := range words {
+		stemmed, err := snowball.Stem(word, language, false)
+		if err != nil {
+			return "", err
+		}
+
+		if slices.Contains[[]string, string](stopWords, stemmed) {
+			continue
+		}
+
+		stemmedSentence = append(stemmedSentence, stemmed)
+	}
+
+	slices.Sort(stemmedSentence)
+	result := slices.Compact(stemmedSentence)
+	return strings.Join(result, " "), nil
+}
+
+func getStopWords() ([]string, error) {
+	resp, err := http.Get("https://gist.githubusercontent.com/rg089/35e00abf8941d72d419224cfd5b5925d/raw/12d899b70156fd0041fa9778d657330b024b959c/stopwords.txt")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(string(data), "\n"), nil
+}

--- a/stem/stem.go
+++ b/stem/stem.go
@@ -1,23 +1,30 @@
 package main
 
 import (
-	"io"
-	"net/http"
 	"slices"
 	"strings"
 
 	"github.com/kljensen/snowball"
 )
 
-func Stem(words []string, language Language) (string, error) {
-	stopWords, err := getStopWords()
+type Stemmer interface {
+	Stem(words []string)
+}
+
+type SnowballStemmer struct {
+	language      Language
+	stopWordsFunc func() ([]string, error)
+}
+
+func (s SnowballStemmer) Stem(words []string) (string, error) {
+	stopWords, err := s.stopWordsFunc()
 	if err != nil {
 		return "", err
 	}
 
 	stemmedSentence := make([]string, 0, len(words))
 	for _, word := range words {
-		stemmed, err := snowball.Stem(word, language, false)
+		stemmed, err := snowball.Stem(word, s.language, false)
 		if err != nil {
 			return "", err
 		}
@@ -32,17 +39,4 @@ func Stem(words []string, language Language) (string, error) {
 	slices.Sort(stemmedSentence)
 	result := slices.Compact(stemmedSentence)
 	return strings.Join(result, " "), nil
-}
-
-func getStopWords() ([]string, error) {
-	resp, err := http.Get("https://gist.githubusercontent.com/rg089/35e00abf8941d72d419224cfd5b5925d/raw/12d899b70156fd0041fa9778d657330b024b959c/stopwords.txt")
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	return strings.Split(string(data), "\n"), nil
 }

--- a/stem/stem.go
+++ b/stem/stem.go
@@ -7,15 +7,18 @@ import (
 	"github.com/kljensen/snowball"
 )
 
+// A Stemmer reduces inflected words to their word stem
 type Stemmer interface {
 	Stem(words []string)
 }
 
+// A SnowballStemmer is a concrete implementation of Stemmer interface
 type SnowballStemmer struct {
-	language      Language
-	stopWordsFunc func() ([]string, error)
+	language      Language                 // Word's language
+	stopWordsFunc func() ([]string, error) // Function that returns stop words
 }
 
+// Stem returns whitspace-separated string with stemmed words and error if occured
 func (s SnowballStemmer) Stem(words []string) (string, error) {
 	stopWords, err := s.stopWordsFunc()
 	if err != nil {

--- a/stem/stem_test.go
+++ b/stem/stem_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	someErr         = fmt.Errorf("some error")
+	stopWordExample = "you"
+	testSentence    = "i'll follow you as long as you are following me"
+)
+
+func TestStem(t *testing.T) {
+
+	testTable := []struct {
+		StopWordsFunc  func() ([]string, error)
+		ExpectedString string
+		ExpectedError  error
+	}{
+		{
+			StopWordsFunc:  func() ([]string, error) { return []string{}, someErr },
+			ExpectedString: "",
+			ExpectedError:  someErr,
+		},
+		{
+			StopWordsFunc:  func() ([]string, error) { return []string{stopWordExample}, nil },
+			ExpectedString: "are as follow i'll long me",
+			ExpectedError:  nil,
+		},
+	}
+
+	stemmer := SnowballStemmer{
+		language: English,
+	}
+	for _, testCase := range testTable {
+		stemmer.stopWordsFunc = testCase.StopWordsFunc
+		gotStr, gotErr := stemmer.Stem(strings.Split(testSentence, " "))
+
+		assert.Equal(t, testCase.ExpectedString, gotStr)
+		assert.Equal(t, testCase.ExpectedError, gotErr)
+	}
+
+}


### PR DESCRIPTION
**Changes to logic**
Добавлена имплементация консольной утилиты для стемминга.
При запуске передаётся флаг s, который является обязательным.
Часто употребляемые слова (stop words) берутся из открытого источника посредством Get-запроса

**Further steps**
Вынести файл со stop words во внутреннее хранилище над которым есть контроль

**Tests**
Написаны юниты-тесты, процент покрытия и покрытый код можно увидеть в артефактах прекоммита
Добавлен прекоммит golangci-lint, результат можно увидеть в билдах